### PR TITLE
Update MoveNodePrivilege.php

### DIFF
--- a/Classes/Security/Authorization/Privilege/Node/MoveNodePrivilege.php
+++ b/Classes/Security/Authorization/Privilege/Node/MoveNodePrivilege.php
@@ -47,12 +47,14 @@ class MoveNodePrivilege extends AbstractNodePrivilege
             // - NodeOperations -> create
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
             foreach ($backtrace as $item) {
-                if (
-                    ($item['function'] === 'apply' && (strpos($item['class'], 'Neos\Neos\Ui\Domain\Model\Changes\CreateAfter') === 0 || strpos($item['class'], 'Neos\Neos\Ui\Domain\Model\Changes\CreateBefore') === 0))
-                    || ($item['function'] === 'create' && strpos($item['class'], 'Neos\Neos\Service\NodeOperations') === 0)
-                    || (strpos($item['class'], 'Neos\ContentRepository\Domain\Model\Node') === 0 && ($item['function'] === 'copyBefore' || $item['function'] === 'copyAfter'))
-                ) {
-                    return false;
+                if (isset($item['class'])) {
+                    if (
+                        ($item['function'] === 'apply' && (strpos($item['class'], 'Neos\Neos\Ui\Domain\Model\Changes\CreateAfter') === 0 || strpos($item['class'], 'Neos\Neos\Ui\Domain\Model\Changes\CreateBefore') === 0))
+                        || ($item['function'] === 'create' && strpos($item['class'], 'Neos\Neos\Service\NodeOperations') === 0)
+                        || (strpos($item['class'], 'Neos\ContentRepository\Domain\Model\Node') === 0 && ($item['function'] === 'copyBefore' || $item['function'] === 'copyAfter'))
+                    ) {
+                        return false;
+                    }
                 }
             }
 

--- a/Classes/Security/Authorization/Privilege/Node/MoveNodePrivilege.php
+++ b/Classes/Security/Authorization/Privilege/Node/MoveNodePrivilege.php
@@ -45,7 +45,7 @@ class MoveNodePrivilege extends AbstractNodePrivilege
             // - CreateBefore, CreatAfter -> apply()
             // - Node(Interface) -> copyBefore, copyAfter
             // - NodeOperations -> create
-            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 15);
             foreach ($backtrace as $item) {
                 if (isset($item['class'])) {
                     if (


### PR DESCRIPTION
A php notice prevents moving nodes in development context because `$item['class']` is not set. E.g. see the following `$item`:
```
array (
  'file' => '/tmp/Development/Cache/Code/Flow_Object_Classes/Neos_Flow_Security_Authorization_PrivilegeManager.php',
  'line' => 81,
  'function' => 'array_filter',
)
```